### PR TITLE
autocomplete를 지원하는 브라우저에서의 댓글 저장문제 해결

### DIFF
--- a/src/components/write_comment.vue
+++ b/src/components/write_comment.vue
@@ -9,7 +9,7 @@
         </div>
         <div class="refresher-comment-body">
             <div :class="{focus: focused, disable: disabled}" class="refresher-input-wrap">
-                <input id="comment_main" v-model="text" :disabled="disabled"
+                <input id="comment_main" v-model="text" autocomplete="off" :disabled="disabled"
                        :placeholder="this.getDccon() === null ? '댓글 입력...' : '디시콘이 선택됐습니다, 댓글 내용이 무시됩니다.'" @blur="blur"
                        @focus="focus" @keydown="type"/>
             </div>


### PR DESCRIPTION
https://stackoverflow.com/questions/9261071/how-to-prevent-browser-from-remembering-text-field-content

autocomplete="off"를 추가함으로써 브라우저가 자동으로 저장하는것을 막을수 있는것으로 보입니다. docs대로 설치하여 테스트하고자 하였으나 테스트 환경 설치에 실패하여 명확히 확인할수 없는점 꼭 확인 부탁드립니다.