### PR TITLE
디시콘 팝업 UI 레이아웃 개선

### DIFF
--- a/src/components/dccon.vue
+++ b/src/components/dccon.vue
@@ -34,7 +34,7 @@
         <template v-else>
             <hr/>
 
-            <ul style="overflow: auto; display: flex; user-select: none; justify-content: center">
+            <ul style="overflow-x: auto; overflow-y: hidden; display: flex; user-select: none; column-gap: 4px;">
                 <li
                     style="font-size: 30px; margin-right: 5px"
                     @click="pageDown()"
@@ -44,11 +44,13 @@
                 <li
                     v-for="dccon in dcconList[currentPage]"
                     :key="dccon.title"
+                    style="width: auto;"
                 >
                     <img
                         :alt="dccon.title"
                         :src="dccon.main_img_url"
                         @click="dcconListClick(dccon.detail)"
+                        style="object-fit: cover; width: 100%; height: 100%; max-width: 53.3px; max-height: 53.3px; "
                     />
                 </li>
                 <li
@@ -70,7 +72,7 @@
                 </h2>
                 <ul
                     v-else
-                    style="display: flex; flex-wrap: wrap"
+                    style="display: grid; grid-template-columns: repeat(6, 1fr); gap: 4px;"
                 >
                     <li
                         v-for="dccon in currentDccon"
@@ -79,7 +81,7 @@
                         <img
                             :alt="dccon.title"
                             :src="dccon.list_img"
-                            style="height: 100px"
+                            style="height: 100px; width: 100%; object-fit: contain;"
                         />
                     </li>
                 </ul>

--- a/src/components/dccon.vue
+++ b/src/components/dccon.vue
@@ -50,7 +50,7 @@
                         :alt="dccon.title"
                         :src="dccon.main_img_url"
                         @click="dcconListClick(dccon.detail)"
-                        style="object-fit: cover; width: 100%; height: 100%; max-width: 53.3px; max-height: 53.3px; "
+                        style="object-fit: cover; width: 100%; max-width: 53.3px; max-height: 53.3px;"
                     />
                 </li>
                 <li


### PR DESCRIPTION
## 변경사항

- 상세 디시콘 목록을 flex에서 grid(6열)로 변경해 gap을 줘도 열 수가 줄지 않도록 수정
- 상단 디시콘 목록 크기 조절
- 상단 디시콘 슬라이더에 column-gap 추가 및 세로 스크롤 제거

## 스크린샷

| 수정 전 | 수정 후 |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/33af11ff-9dcc-4d84-81e5-a2b9ac598a3d) | ![after](https://github.com/user-attachments/assets/d7be6fd5-2924-4a1b-9a18-a1c2497bbca7) |
