### PR TITLE
fix(layout): hide gallery banner ads and optimize header height in compact mode

### DIFF
--- a/src/assets/styles/layout.scss
+++ b/src/assets/styles/layout.scss
@@ -116,6 +116,14 @@
         display: none;
     }
 
+    .issue_wrap .banner_box,
+    #ad-layer,
+    .ad-layer,
+    #ad-layer-closer,
+    .ad-layer-closer {
+        display: none !important;
+    }
+
     .input_write_tit {
         float: initial;
     }

--- a/src/assets/styles/layout.scss
+++ b/src/assets/styles/layout.scss
@@ -24,7 +24,8 @@
     }
 
     .dchead {
-        height: 100px;
+        height: auto;
+        min-height: 36px;
     }
 
     .list_wrap .dc_logo,
@@ -38,6 +39,7 @@
 
     .area_links {
         right: 13px;
+        top: 6px;
     }
 
     .dc_logo {
@@ -120,7 +122,8 @@
     #ad-layer,
     .ad-layer,
     #ad-layer-closer,
-    .ad-layer-closer {
+    .ad-layer-closer,
+    #hdline_ban {
         display: none !important;
     }
 


### PR DESCRIPTION
### 변경 사항
1. **컴팩트 모드 배너 및 팝업 레이어 광고 숨김**
   - 갤러리 상단 이슈박스의 배너 광고(`.issue_wrap .banner_box`) 숨김 처리
   - 화면 오버레이 레이어 팝업 광고(`#ad-layer`, `.ad-layer`, `#ad-layer-closer`, `.ad-layer-closer`) 숨김 처리
   - 상단 헤드라인 배너 광고(`#hdline_ban`) 숨김 처리

2. **컴팩트 모드 헤더 높이 최적화**
   - 로고, 검색창, 광고가 숨겨진 상태에서 고정 높이(`height: 100px`)로 인해 발생하던 상단 빈 여백 제거
   - `.dchead`의 높이를 `height: auto; min-height: 36px;`로 개선 및 `.area_links` 여백 정렬

### 목적
컴팩트 모드 사용 시 불필요한 배너/팝업 광고를 가리고, 상단 빈 여백을 줄여 본문 영역을 더 깔끔하고 넓게 볼 수 있도록 개선했습니다.