### PR TITLE
fix(layout): hide side wing and article bottom banner ads in compact mode

### DIFF
--- a/src/assets/styles/layout.scss
+++ b/src/assets/styles/layout.scss
@@ -122,7 +122,11 @@
     .ad-layer,
     #ad-layer-closer,
     .ad-layer-closer,
-    #hdline_ban {
+    #hdline_ban,
+    .ad_left_wing_list_top,
+    .ad_right_wing_list_top,
+    .ad_left_wing_list_top + div,
+    div:has(> a[href*="_wing_"]) {
         display: none !important;
     }
 

--- a/src/assets/styles/layout.scss
+++ b/src/assets/styles/layout.scss
@@ -113,22 +113,36 @@
         display: none;
     }
 
-    .ad_bottom_list {
-        display: none;
-    }
-
-    .issue_wrap .banner_box,
+    .ad_bottom_list,
+    .banner_box,
+    .con_banner,
+    .writing_banbox,
+    .rightbanner1,
+    .stickyunit,
+    ._BTN_AD_,
+    #ad_floating,
     #ad-layer,
     .ad-layer,
     #ad-layer-closer,
     .ad-layer-closer,
     #hdline_ban,
+    #ad_nv_slot,
+    #zzbang_ad,
+    #gaejukimg,
+    .moveimg,
+    .moveimglink,
+    .click-blocker,
+    div[id^="foin_"],
+    iframe[id^="ad_frame"],
+    ins.adsbygoogle,
+    ins.kakao_ad_area,
     .ad_left_wing_list_top,
     .ad_right_wing_list_top,
     .ad_left_wing_list_top + div,
     div:has(> a[href*="_wing_"]),
     div:has(> ins.adsbygoogle),
-    div:has(> ins.kakao_ad_area) {
+    div:has(> ins.kakao_ad_area),
+    tr.ub-content:has(em.icon_ad) {
         display: none !important;
     }
 

--- a/src/assets/styles/layout.scss
+++ b/src/assets/styles/layout.scss
@@ -126,7 +126,9 @@
     .ad_left_wing_list_top,
     .ad_right_wing_list_top,
     .ad_left_wing_list_top + div,
-    div:has(> a[href*="_wing_"]) {
+    div:has(> a[href*="_wing_"]),
+    div:has(> ins.adsbygoogle),
+    div:has(> ins.kakao_ad_area) {
         display: none !important;
     }
 


### PR DESCRIPTION
### 변경 사항
1. **컴팩트 모드(`.refresherCompact`) 좌/우 날개 배너 광고 숨김**
   - 좌측 날개 광고(`.ad_left_wing_list_top`) 및 우측 날개 광고(클래스/ID 없는 `div`) 숨김 처리
   - NetInsight 고유 존 키(`_wing_`) 기반 직계 링크 선택자(`div:has(> a[href*="_wing_"])`)를 적용하여 갤러리 종류(일반/마이너/미니) 및 페이지 유형(목록/본문)에 관계없이 안정적으로 타겟팅
   - 클래스 및 인접 형제 선택자(`+ div`)를 병행 적용하여 uBlock 등 타 광고 차단기가 내부 요소를 제거했을 때 발생하는 360×840px 투명 레이아웃 껍데기 잔여 문제 방어

2. **컴팩트 모드(`.refresherCompact`) 본문 하단 배너 광고 숨김**
   - 본문 하단에 삽입되는 구글 애드센스(`div:has(> ins.adsbygoogle)`) 및 카카오 애드핏(`div:has(> ins.kakao_ad_area)`) 컨테이너 숨김 처리

3. **컴팩트 모드(`.refresherCompact`) 기타 광고 배너 및 토스트/목록/플로팅 광고 숨김**
   - 플로팅 광고 배너 (`#ad_floating`)
   - ADN 플로팅 토스트 배너 (`div[id^="foin_"]`, `iframe[id^="ad_frame"]`)
   - 상단 배너 박스 및 팝업 레이어 (`.banner_box`, `#ad-layer`, `.ad-layer`, `#ad-layer-closer`, `.ad-layer-closer`)
   - 본문 우측 배너 (`.con_banner`, `.writing_banbox`), 본문 상·하단/짤방 슬롯 (`#ad_nv_slot`, `#zzbang_ad`)
   - 글 목록 내 광고 행 (`tr.ub-content:has(em.icon_ad)`)
   - 개죽이 팝업 및 클릭 차단 오버레이 (`#gaejukimg`, `.moveimg`, `.click-blocker`)

### 스크린샷 (광고 노출 상태)
| 좌측 날개 배너 | 우측 날개 배너 |
| :---: | :---: |
| ![Screenshot.From.2026-08-25.09-05-57.png](https://github.com/user-attachments/assets/16fa014d-9a81-44b4-89f9-89bebe001e18) | ![Screenshot.From.2026-08-25.09-06-04.png](https://github.com/user-attachments/assets/6b9423a1-2fd7-4876-b819-e4624015966e) |

| 본문 하단 배너 |
| :---: |
| ![Screenshot.From.2026-08-25.09-23-03.png](https://github.com/user-attachments/assets/59b55ed1-da9b-4bfc-8178-2177f68a2523) |